### PR TITLE
fix: On-screen touch cmoving player properly

### DIFF
--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/poohfarmer/PoohFarmerCartridge.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/poohfarmer/PoohFarmerCartridge.java
@@ -34,8 +34,14 @@ public class PoohFarmerCartridge
 
 
     //CURRENTLY, USED TO MOVE PLAYER!!!
-    private int xCenterScreen;
-    private int yCenterScreen;
+    private int xScreenFirstThird;
+    private int xScreenSecondThird;
+    private int yScreenFirstThird;
+    private int yScreenSecondThird;
+    //private int xCenterScreen;
+    //private int yCenterScreen;
+
+
     private boolean cantPress = false;
     private boolean justPressed = false;
     private boolean pressing = false;
@@ -54,8 +60,12 @@ public class PoohFarmerCartridge
         Log.d(MainActivity.DEBUG_TAG, "pixelToScreenRatio: " + pixelToScreenRatio);
 
 
-        xCenterScreen = sideSquareScreen / 2;
-        yCenterScreen = sideSquareScreen / 2;
+        xScreenFirstThird = (int)((float)sideSquareScreen / 3);
+        xScreenSecondThird = (int)(2 * ((float)sideSquareScreen / 3));
+        yScreenFirstThird = (int)((float)sideSquareScreen / 3);
+        yScreenSecondThird = (int)(2 * ((float)sideSquareScreen / 3));
+        //xCenterScreen = sideSquareScreen / 2;
+        //yCenterScreen = sideSquareScreen / 2;
 
 
         player = new Player(sideSquareScreen, pixelToScreenRatio);
@@ -95,7 +105,7 @@ public class PoohFarmerCartridge
         if (justPressed) {
             //HORIZONTAL
             //left
-            if (event.getX() < xCenterScreen && event.getY() < yCenterScreen) {
+            if (event.getX() < xScreenFirstThird && event.getY() > yScreenFirstThird && event.getY() < yScreenSecondThird) {
                 int xFuture = (int) (player.getxCurrent() - player.getMoveSpeed());
                 int yFutureTop = (int) (player.getyCurrent());
                 int yFutureBottom = (int) (player.getyCurrent() + player.getHeight() - 1);
@@ -106,7 +116,7 @@ public class PoohFarmerCartridge
                 }
             }
             //right
-            else if (event.getX() > xCenterScreen && event.getY() > yCenterScreen) {
+            else if (event.getX() > xScreenSecondThird && event.getY() > yScreenFirstThird && event.getY() < yScreenSecondThird) {
                 int xFuture = (int) ((player.getxCurrent() + player.getWidth()) + player.getMoveSpeed() - 1);
                 int yFutureTop = (int) (player.getyCurrent());
                 int yFutureBottom = (int) (player.getyCurrent() + player.getHeight() - 1);
@@ -119,7 +129,7 @@ public class PoohFarmerCartridge
 
             //VERTICAL
             //up
-            if (event.getY() < yCenterScreen && event.getX() > xCenterScreen) {
+            if (event.getY() < yScreenFirstThird && event.getX() > xScreenFirstThird && event.getX() < xScreenSecondThird) {
                 int yFuture = (int) (player.getyCurrent() - player.getMoveSpeed());
                 int xFutureLeft = (int) (player.getxCurrent());
                 int xFutureRight = (int) (player.getxCurrent() + player.getWidth() - 1);
@@ -130,7 +140,7 @@ public class PoohFarmerCartridge
                 }
             }
             //down
-            else if (event.getY() > yCenterScreen && event.getX() < xCenterScreen) {
+            else if (event.getY() > yScreenSecondThird && event.getX() > xScreenFirstThird && event.getX() < xScreenSecondThird) {
                 int yFuture = (int) ((player.getyCurrent() + player.getHeight()) + player.getMoveSpeed() - 1);
                 int xFutureLeft = (int) (player.getxCurrent());
                 int xFutureRight = (int) (player.getxCurrent() + player.getWidth() - 1);


### PR DESCRIPTION
Instead of dividing the game screen into 2 pieces horizontally and 2 pieces vertically, it's now being divided into 3 pieces horizontally and 3 pieces vertically. Adjusted the conditions used to translate the MotionEvent's x and y position into left, up, right, and down. The previous attempt (the 2-piece version) wasn't able to separate out horizontal and vertical movement properly; it was enough to move the player sprite around the scene, but it was buggy/not-as-intended (there were 4 quadrants... the top-left moved the player left, the top-right moved the player up, the bottom-left moved the player down, and the bottom-right moved the player right... or something similar to that). Now, on-screen touch events respond more like a directional pad.