### PR TITLE
feat: Add "swap game" button to switch GameCartridge

### DIFF
--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/GameView.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/GameView.java
@@ -25,6 +25,9 @@ public class GameView extends SurfaceView
     private int widthScreen;
     private int heightScreen;
 
+    private SurfaceHolder surfaceHolder;
+    private int sideSquareScreen;
+
     public GameView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
@@ -90,7 +93,10 @@ public class GameView extends SurfaceView
 
         widthScreen = getWidth();
         heightScreen = getHeight();
-        int sideSquareScreen = Math.min(widthScreen, heightScreen);
+
+
+        surfaceHolder = holder;
+        sideSquareScreen = Math.min(widthScreen, heightScreen);
 
 
         SurfaceView gameView = (SurfaceView) findViewById(R.id.gameView);
@@ -101,7 +107,7 @@ public class GameView extends SurfaceView
         /////////////////////////
 
 
-        gameCartridge = new PoohFarmerCartridge(getContext(), holder, getResources(), sideSquareScreen);
+        gameCartridge = new PoohFarmerCartridge(getContext(), surfaceHolder, getResources(), sideSquareScreen);
         //gameCartridge = new PongCartridge(getContext(), holder, getResources(), widthScreen, heightScreen);
         runner = new GameRunner(gameCartridge);
         // Tell the Thread class to go to the "public void run()" method.
@@ -136,6 +142,37 @@ public class GameView extends SurfaceView
                 }
             }
         }
+    }
+
+    public void switchGame(boolean isPoohFarmer) {
+        Log.d(MainActivity.DEBUG_TAG, "GameView.switchGame(boolean)");
+
+        runner.shutdown();
+        /*
+        NOW: want to wait for the thread to stop drawing.
+        Want to NOT allow the phone to go to another application until
+        this runner has stopped drawing... because if it goes to another
+        application, the surface will no longer exist yet the thread will
+        still be try to renderGame on it which will cause it to CRASH.
+        */
+        while (runner != null) {
+            // This method waits for the thread to terminate.
+            try {
+                runner.join();
+                runner = null;
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (isPoohFarmer) {
+            gameCartridge = new PoohFarmerCartridge(getContext(), surfaceHolder, getResources(), sideSquareScreen);
+        } else {
+            gameCartridge = new PongCartridge(getContext(), surfaceHolder, getResources(), sideSquareScreen, sideSquareScreen);;
+        }
+        runner = new GameRunner(gameCartridge);
+        // Tell the Thread class to go to the "public void run()" method.
+        runner.start();
     }
 
 }

--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/JackInActivity.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/JackInActivity.java
@@ -3,15 +3,31 @@ package com.jackingaming.notesquirrel.gameboycolor;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
 
 import com.jackingaming.notesquirrel.R;
 
 public class JackInActivity extends AppCompatActivity {
 
+    private boolean isPoohFarmer;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_jack_in);
+
+        final GameView gameView = (GameView) findViewById(R.id.gameView);
+        Button swapGameButton = (Button) findViewById(R.id.swap_game);
+        isPoohFarmer = true;
+
+        swapGameButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                isPoohFarmer = !isPoohFarmer;
+                gameView.switchGame(isPoohFarmer);
+            }
+        });
 
         /*
         GameView gameView = (GameView) findViewById(R.id.game);

--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/poohfarmer/sprites/Assets.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/poohfarmer/sprites/Assets.java
@@ -84,7 +84,9 @@ public class Assets {
         initEntities(resources);
 
         initDPad(resources);
-        initPokemonWorldMap(resources);
+
+        //TODO:
+        //initPokemonWorldMap(resources);
     }
 
     private static void initEntities(Resources resources) {

--- a/app/src/main/res/layout/activity_jack_in.xml
+++ b/app/src/main/res/layout/activity_jack_in.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/relativeLayout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/relativeLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#00FF00"
@@ -22,5 +22,15 @@
         android:layout_alignParentBottom="true"
         android:layout_marginLeft="10dp"
         android:layout_marginBottom="10dp" />
+
+    <Button
+        android:id="@+id/swap_game"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginRight="10dp"
+        android:layout_marginBottom="10dp"
+        android:text="swap game" />
 
 </RelativeLayout>


### PR DESCRIPTION
In GameView.switchGame(boolean), the presently running thread is shutdown, a new instance of GameCartridge is instantiated, and a new thread will run.

The previous "run" of PoohFarmerCartridge is not saved and therefore the user is starting over from the beginning of the game. This is also true for PongCartridge (but isn't as significant because "runs" of this game is much shorter).

The screen's user input layout doesn't change when in PongCartridge (there's still a directional pad and the "swap game" button in the bottom half of the screen (this game is no longer full screen).