### PR TITLE
refactor: Move instantiation of GameCartridge to JackInActivity

### DIFF
--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/GameView.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/GameView.java
@@ -23,10 +23,10 @@ public class GameView extends SurfaceView
     private GameCartridge gameCartridge;
     private GameRunner runner;
 
+    private SurfaceHolder holder;
+
     private int widthScreen;
     private int heightScreen;
-
-    private SurfaceHolder surfaceHolder;
     private int sideSquareScreen;
 
     public GameView(Context context, AttributeSet attrs) {
@@ -57,14 +57,6 @@ public class GameView extends SurfaceView
         return true;
     }
 
-    public void onDirectionalPadTouched(DirectionalPadFragment.Direction direction) {
-        gameCartridge.onDirectionalPadInput(direction);
-    }
-
-    public void onButtonPadTouched(ButtonPadFragment.InputButton inputButton) {
-        gameCartridge.onButtonPadInput(inputButton);
-    }
-
     /**
      * We don't call this method directly, it's used by the SurfaceHolder.Callback interface.
      */
@@ -81,38 +73,13 @@ public class GameView extends SurfaceView
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
         Log.d(MainActivity.DEBUG_TAG, "GameView.surfaceCreated(SurfaceHolder)");
-        ////////////////////////////////////////////////////////////////////////////////
-        /*
-        final Activity jackInActivity = (Activity)getContext();
-        RelativeLayout relativeLayout = (RelativeLayout) jackInActivity.findViewById(R.id.relativeLayout);
 
-        Button button = new Button(jackInActivity);
-        RelativeLayout.LayoutParams layout = new RelativeLayout.LayoutParams(
-                RelativeLayout.LayoutParams.WRAP_CONTENT,
-                RelativeLayout.LayoutParams.WRAP_CONTENT
-        );
-        layout.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
-        layout.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-        button.setLayoutParams(layout);
-        button.setText("myButton");
-        button.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Log.d(MainActivity.DEBUG_TAG, "kill switch engaged");
-            }
-        });
-
-        relativeLayout.addView(button);
-        */
-        ////////////////////////////////////////////////////////////////////////////////
-
+        this.holder = holder;
 
         widthScreen = getWidth();
         heightScreen = getHeight();
-
-
-        surfaceHolder = holder;
         sideSquareScreen = Math.min(widthScreen, heightScreen);
+
 
 
         SurfaceView gameView = (SurfaceView) findViewById(R.id.gameView);
@@ -122,27 +89,34 @@ public class GameView extends SurfaceView
         gameView.requestLayout();
         /////////////////////////
 
-        //TODO: DON'T INSTANTIATE NEW INSTANCE... OTHERWISE LOSE DATA EVERYTIME SCREEN CREATED!!!
-        gameCartridge = new PoohFarmerCartridge(getContext(), surfaceHolder, getResources(), sideSquareScreen);
-        //gameCartridge = new PongCartridge(getContext(), holder, getResources(), widthScreen, heightScreen);
 
-
-        ///////////////////////////////////////////////////////////////////////
-        gameCartridge.init();
-        if ( ((JackInActivity)getContext()).getSavedInstanceState() != null ) {
-            Log.d(MainActivity.DEBUG_TAG, "GameView.surfaceCreated(SurfaeHolder) calling gameCartridge().loadSavedState()");
-            gameCartridge.loadSavedState();
-        }
-        ///////////////////////////////////////////////////////////////////////
-
-
-        runner = new GameRunner(gameCartridge);
-        // Tell the Thread class to go to the "public void run()" method.
-        runner.start();
+        ///////////////////
+        runGameCartridge();
+        ///////////////////
     }
 
-    public GameCartridge getGameCartridge() {
-        return gameCartridge;
+    private void runGameCartridge() {
+        Log.d(MainActivity.DEBUG_TAG, "GameView.runGameCartridge()");
+
+        //////////////////////////////////////////////////////////////////
+        gameCartridge = ((JackInActivity)getContext()).getGameCartridge();
+        //////////////////////////////////////////////////////////////////
+
+        if (gameCartridge != null) {
+            ///////////////////////////////////////////////////////////////////////
+            gameCartridge.init(holder, sideSquareScreen);
+            if (((JackInActivity)getContext()).getSavedInstanceState() != null) {
+                Log.d(MainActivity.DEBUG_TAG, "GameView.runGameCartridge() calling gameCartridge.loadSavedState()");
+                gameCartridge.loadSavedState();
+            }
+            ///////////////////////////////////////////////////////////////////////
+
+            runner = new GameRunner(gameCartridge);
+            // Tell the Thread class to go to the "public void run()" method.
+            runner.start();
+        } else {
+            Log.d(MainActivity.DEBUG_TAG, "ERROR: GameView.gameCartridge is null!!!!!!!!!!");
+        }
     }
 
     /**
@@ -175,6 +149,7 @@ public class GameView extends SurfaceView
         }
     }
 
+    //TODO: move to JackInActivity?
     public void switchGame(boolean isPoohFarmer) {
         Log.d(MainActivity.DEBUG_TAG, "GameView.switchGame(boolean)");
 
@@ -197,15 +172,15 @@ public class GameView extends SurfaceView
         }
 
         if (isPoohFarmer) {
-            gameCartridge = new PoohFarmerCartridge(getContext(), surfaceHolder, getResources(), sideSquareScreen);
+            gameCartridge = new PoohFarmerCartridge(getContext(), getResources());
         } else {
-            gameCartridge = new PongCartridge(getContext(), surfaceHolder, getResources(), sideSquareScreen, sideSquareScreen);;
+            gameCartridge = new PongCartridge(getContext(), getResources());
         }
 
         ///////////////////////////////////////////////////////////////////////
-        gameCartridge.init();
+        gameCartridge.init(holder, sideSquareScreen);
         if ( ((JackInActivity)getContext()).getSavedInstanceState() != null ) {
-            Log.d(MainActivity.DEBUG_TAG, "GameView.surfaceCreated(SurfaeHolder) calling gameCartridge().loadSavedState()");
+            Log.d(MainActivity.DEBUG_TAG, "GameView.sswitchGame(boolean) calling gameCartridge.loadSavedState()");
             gameCartridge.loadSavedState();
         }
         ///////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/JackInActivity.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/JackInActivity.java
@@ -10,6 +10,8 @@ import android.widget.Button;
 
 import com.jackingaming.notesquirrel.MainActivity;
 import com.jackingaming.notesquirrel.R;
+import com.jackingaming.notesquirrel.gameboycolor.gamecartridges.GameCartridge;
+import com.jackingaming.notesquirrel.gameboycolor.gamecartridges.poohfarmer.PoohFarmerCartridge;
 import com.jackingaming.notesquirrel.gameboycolor.input.ButtonPadFragment;
 import com.jackingaming.notesquirrel.gameboycolor.input.DirectionalPadFragment;
 import com.jackingaming.notesquirrel.sandbox.learnfragment.FragmentParentDvdActivity;
@@ -18,6 +20,8 @@ public class JackInActivity extends AppCompatActivity {
 
     private Bundle savedInstanceState;
     private boolean isPoohFarmer;
+
+    private GameCartridge gameCartridge;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -33,14 +37,14 @@ public class JackInActivity extends AppCompatActivity {
         directionalPadFragment.setOnDirectionalPadTouchListener(new DirectionalPadFragment.OnDirectionalPadTouchListener() {
             @Override
             public void onDirectionalPadTouched(DirectionalPadFragment.Direction direction) {
-                gameView.onDirectionalPadTouched(direction);
+                gameCartridge.onDirectionalPadInput(direction);
             }
         });
 
         buttonPadFragment.setOnButtonPadTouchListener(new ButtonPadFragment.OnButtonPadTouchListener() {
             @Override
             public void onButtonPadTouched(ButtonPadFragment.InputButton inputButton) {
-                gameView.onButtonPadTouched(inputButton);
+                gameCartridge.onButtonPadInput(inputButton);
             }
         });
 
@@ -65,6 +69,10 @@ public class JackInActivity extends AppCompatActivity {
 
 
 
+        gameCartridge = new PoohFarmerCartridge(this, getResources());
+        //gameCartridge = new PongCartridge(getContext(), holder, getResources(), widthScreen, heightScreen);
+
+
 
         /////////////////////////////////////////////
         this.savedInstanceState = savedInstanceState;
@@ -81,6 +89,10 @@ public class JackInActivity extends AppCompatActivity {
 
     }
 
+    public GameCartridge getGameCartridge() {
+        return gameCartridge;
+    }
+
     public Bundle getSavedInstanceState() {
         return savedInstanceState;
     }
@@ -89,18 +101,6 @@ public class JackInActivity extends AppCompatActivity {
     protected void onStart() {
         super.onStart();
         Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onStart()");
-
-        /*
-        if (savedInstanceState == null) {
-            Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onStart() Bundle savedInstanceState is null: " + savedInstanceState);
-        } else {
-            Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onStart() Bundle savedInstanceState is NOT null: " + savedInstanceState);
-
-            GameView gameView = (GameView) findViewById(R.id.gameView);
-            Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onPause() calling gameView.getGameCartridge().loadSavedState()");
-            gameView.getGameCartridge().loadSavedState();
-        }
-        */
     }
 
     @Override
@@ -115,9 +115,8 @@ public class JackInActivity extends AppCompatActivity {
         Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onPause()");
 
         ///////////////////////////////////////////////////////////
-        GameView gameView = (GameView) findViewById(R.id.gameView);
-        Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onPause() calling gameView.getGameCartridge().savePresentState()");
-        gameView.getGameCartridge().savePresentState();
+        Log.d(MainActivity.DEBUG_TAG, "JackInActivity.onPause() calling gameCartridge.savePresentState()");
+        gameCartridge.savePresentState();
         ///////////////////////////////////////////////////////////
     }
 

--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/GameCartridge.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/GameCartridge.java
@@ -1,12 +1,13 @@
 package com.jackingaming.notesquirrel.gameboycolor.gamecartridges;
 
 import android.view.MotionEvent;
+import android.view.SurfaceHolder;
 
 import com.jackingaming.notesquirrel.gameboycolor.input.ButtonPadFragment;
 import com.jackingaming.notesquirrel.gameboycolor.input.DirectionalPadFragment;
 
 public interface GameCartridge {
-    public void init();
+    public void init(SurfaceHolder holder, int sideSquareScreen);
     public void savePresentState();
     public void loadSavedState();
     public void onScreenInput(MotionEvent event);

--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/pong/PongCartridge.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/pong/PongCartridge.java
@@ -33,6 +33,7 @@ public class PongCartridge
     private Context context;
     private SurfaceHolder holder;
     private Resources resources;
+    private int sideSquareScreen;
 
     private Ball ball;
     private Bat player;
@@ -47,17 +48,19 @@ public class PongCartridge
     //private SoundPool soundPool;
     private MediaPlayer mediaPlayer;
 
-    public PongCartridge(Context context, SurfaceHolder holder, Resources resources, int widthScreen, int heightScreen) {
+    public PongCartridge(Context context, Resources resources) {
         this.context = context;
-        this.holder = holder;
         this.resources = resources;
+    }
 
-        //soundPool = new SoundPool(5, AudioManager.STREAM_MUSIC, 0);
-        mediaPlayer = MediaPlayer.create(context, R.raw.corporate_ukulele);
+    @Override
+    public void init(SurfaceHolder holder, int sideSquareScreen) {
+        Log.d(MainActivity.DEBUG_TAG, "PongCartridge.init()");
 
-        ball = new Ball(widthScreen, heightScreen);
-        player = new Bat(widthScreen, heightScreen, Bat.Position.LEFT);
-        opponent = new Bat(widthScreen, heightScreen, Bat.Position.RIGHT);
+        this.holder = holder;
+        this.sideSquareScreen = sideSquareScreen;
+
+
 
         textPaint = new Paint();
         //set text's pivot-point to CENTER-OF-TEXT (instead of TOP-LEFT corner).
@@ -66,30 +69,19 @@ public class PongCartridge
         textPaint.setColor(Color.BLUE);
         textPaint.setTextSize(64);
         textPaint.setTypeface(Typeface.DEFAULT_BOLD);
-    }
 
-    @Override
-    public void init() {
-        Log.d(MainActivity.DEBUG_TAG, "PongCartridge.init()");
-
-        //TODO:
-        /*
-        final int startSoundId = soundPool.load(context, R.raw.avicii_tribute_concert, 1);
-        soundPool.setOnLoadCompleteListener(new SoundPool.OnLoadCompleteListener() {
-            @Override
-            public void onLoadComplete(SoundPool soundPool, int sampleId, int status) {
-                if (startSoundId == sampleId) {
-                    soundPool.play(startSoundId, 1, 1, 1, 0, 1f);
-                    Toast.makeText(context, "SoundPool.OnLoadCompleteListener.onLoadComplete(SoundPool, int, int)", Toast.LENGTH_LONG).show();
-                    Log.d(MainActivity.DEBUG_TAG, "@@@@@ SoundPool.OnLoadCompleteListener.onLoadComplete(SoundPool, int, int) @@@@@");
-                }
-            }
-        });
-        */
+        //soundPool = new SoundPool(5, AudioManager.STREAM_MUSIC, 0);
+        mediaPlayer = MediaPlayer.create(context, R.raw.corporate_ukulele);
         mediaPlayer.start();
+
+
 
         Bitmap spriteSheetCorgiCrusade = BitmapFactory.decodeResource(resources, R.drawable.corgi_crusade_editted);
         Bitmap spriteSheetYokoTileset = BitmapFactory.decodeResource(resources, R.drawable.pc_yoko_tileset);
+
+        ball = new Ball(sideSquareScreen, sideSquareScreen);
+        player = new Bat(sideSquareScreen, sideSquareScreen, Bat.Position.LEFT);
+        opponent = new Bat(sideSquareScreen, sideSquareScreen, Bat.Position.RIGHT);
 
         ball.init(spriteSheetCorgiCrusade);
         player.init(spriteSheetYokoTileset);

--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/poohfarmer/PoohFarmerCartridge.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/poohfarmer/PoohFarmerCartridge.java
@@ -55,10 +55,16 @@ public class PoohFarmerCartridge
     private boolean justPressed = false;
     private boolean pressing = false;
 
-    public PoohFarmerCartridge(Context context, SurfaceHolder holder, Resources resources, int sideSquareScreen) {
+    public PoohFarmerCartridge(Context context, Resources resources) {
         this.context = context;
-        this.holder = holder;
         this.resources = resources;
+    }
+
+    @Override
+    public void init(SurfaceHolder holder, int sideSquareScreen) {
+        Log.d(MainActivity.DEBUG_TAG, "PoohFarmerCartridge.init()");
+
+        this.holder = holder;
         this.sideSquareScreen = sideSquareScreen;
         Log.d(MainActivity.DEBUG_TAG, "sideSquareScreen: " + sideSquareScreen);
 
@@ -68,25 +74,18 @@ public class PoohFarmerCartridge
         pixelToScreenRatio = ((float)sideSquareScreen) / sideSquareGameCameraInPixel;
         Log.d(MainActivity.DEBUG_TAG, "pixelToScreenRatio: " + pixelToScreenRatio);
 
-
         xScreenFirstThird = (int)((float)sideSquareScreen / 3);
         xScreenSecondThird = (int)(2 * ((float)sideSquareScreen / 3));
         yScreenFirstThird = (int)((float)sideSquareScreen / 3);
         yScreenSecondThird = (int)(2 * ((float)sideSquareScreen / 3));
-        //xCenterScreen = sideSquareScreen / 2;
-        //yCenterScreen = sideSquareScreen / 2;
 
 
         player = new Player(sideSquareScreen, pixelToScreenRatio);
         gameCamera = new GameCamera();
         sceneCurrent = new Scene(sideSquareScreen);
-    }
 
-    @Override
-    public void init() {
-        Log.d(MainActivity.DEBUG_TAG, "PoohFarmerCartridge.init()");
+
         Assets.init(resources);
-
         sceneCurrent.init(player, gameCamera);
     }
 


### PR DESCRIPTION
GameView.surfaceCreated(SurfaceHolder) will call JackInActivity's gameCartridge's init(SurfaceHolder, int) and loadSavedState() prior to instantiating a GameRunner to run the game cartridge on a separate thread.

Also, the inputs from ButtonPadFragment and DirectionalPadFragment are no longer going through GameView, but are going directly to JackInActivity's gameCartridge.

NEXT: remove the viewport's launching the DVD library activity when touching the bottom-left and bottom-right of the screen, also rework the game switching feature.