### PR TITLE
fix: Loading player's current position within Scene

### DIFF
--- a/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/base/SerializationDoer.java
+++ b/app/src/main/java/com/jackingaming/notesquirrel/gameboycolor/gamecartridges/base/SerializationDoer.java
@@ -157,9 +157,16 @@ public class SerializationDoer {
             ///////////////////////////////////////////////////////////////////////////////////
             GameCamera gameCamera = (GameCamera) os.readObject();
             Player player = (Player) os.readObject();
-            //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+            //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
             player.setName("EeyoreDeserialized");
-            //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+            //TODO: [BUG] loading of ACTUAL/CURRENT position being overwritten
+            // when Scene.restoreSceneStack(ArrayList<Scene.Id>) (it calls
+            // Scene.enter() which sets player's position to xPriorScene and
+            // yPriorScene) gets called.
+            //Will restore ACTUAL/CURRENT position at the end of this loading method.
+            float xCurrent = player.getxCurrent();
+            float yCurrent = player.getyCurrent();
+            //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
             ///////////////////////////////////////////////////////////////////////////////////
 
             //PLAYER AND GAME_CAMERA
@@ -344,6 +351,14 @@ public class SerializationDoer {
             ((GameState)gameCartridge.getStateManager().getStateCollection().get(State.Id.GAME)).getSceneManager().restoreSceneStack(sceneIdsFromSceneStack);
             ((GameState)gameCartridge.getStateManager().getStateCollection().get(State.Id.GAME)).getSceneManager().setGameCamera(gameCamera);
             ((GameState)gameCartridge.getStateManager().getStateCollection().get(State.Id.GAME)).getSceneManager().setPlayer(player);
+
+
+
+            //[FIX] position-bug, player's ACTUAL/CURRENT was set to xPriorScene and yPriorScene.
+            //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+            gameCartridge.getPlayer().setxCurrent(xCurrent);
+            gameCartridge.getPlayer().setyCurrent(yCurrent);
+            //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 
 


### PR DESCRIPTION
Traced and fixed issue of player's position loading improperly (it was being overwritten by xPriorScene and yPriorScene from Scene.enter() within SceneManager.restoreSceneStack(ArrayList<Scene.Id>)).

This reworked SerializationDoer is saving and loading all scenes and states (previous implementations didn't account for all scenes and states... only GameState and whichever were actively on the sceneStack/stateStack). This bug was introduced during this major overhaul of SerializationDoer, but is now fixed!